### PR TITLE
feat(blog): image lightbox on click

### DIFF
--- a/components/ContentImageViewer.tsx
+++ b/components/ContentImageViewer.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { Modal } from "@mantine/core";
+
+export function ContentImageViewer({ children }: { children: React.ReactNode }) {
+  const [src, setSrc] = useState<string | null>(null);
+
+  return (
+    <div
+      onClick={(e) => {
+        const target = e.target as HTMLElement;
+        if (target.tagName === "IMG") {
+          setSrc((target as HTMLImageElement).src);
+        }
+      }}
+      style={{ cursor: "auto" }}
+    >
+      {children}
+      <Modal
+        opened={!!src}
+        onClose={() => setSrc(null)}
+        size="auto"
+        centered
+        withCloseButton
+        padding={0}
+        styles={{ body: { display: "flex" } }}
+      >
+        {src && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={src}
+            alt=""
+            style={{
+              width: "min(900px, 90vw)",
+              height: "auto",
+              maxHeight: "85vh",
+              objectFit: "contain",
+              display: "block",
+            }}
+          />
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/components/ContentImageViewer.tsx
+++ b/components/ContentImageViewer.tsx
@@ -14,7 +14,6 @@ export function ContentImageViewer({ children }: { children: React.ReactNode }) 
           setSrc((target as HTMLImageElement).src);
         }
       }}
-      style={{ cursor: "auto" }}
     >
       {children}
       <Modal
@@ -22,23 +21,54 @@ export function ContentImageViewer({ children }: { children: React.ReactNode }) 
         onClose={() => setSrc(null)}
         size="auto"
         centered
-        withCloseButton
+        radius={0}
         padding={0}
-        styles={{ body: { display: "flex" } }}
+        withCloseButton={false}
+        overlayProps={{ color: "#1C1917", backgroundOpacity: 0.72 }}
+        styles={{
+          content: {
+            background: "#FDFCF9",
+            border: "1px solid #C9C3B8",
+            boxShadow: "none",
+          },
+          body: { display: "flex", flexDirection: "column" },
+        }}
       >
         {src && (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={src}
-            alt=""
-            style={{
-              width: "min(900px, 90vw)",
-              height: "auto",
-              maxHeight: "85vh",
-              objectFit: "contain",
-              display: "block",
-            }}
-          />
+          <div style={{ position: "relative" }}>
+            <button
+              onClick={() => setSrc(null)}
+              aria-label="닫기"
+              style={{
+                position: "absolute",
+                top: 12,
+                right: 12,
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                color: "#86807A",
+                fontSize: 18,
+                lineHeight: 1,
+                padding: "4px 8px",
+                zIndex: 1,
+                letterSpacing: "-0.5px",
+              }}
+            >
+              ✕
+            </button>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={src}
+              alt=""
+              style={{
+                width: "min(900px, 90vw)",
+                height: "auto",
+                maxHeight: "85vh",
+                objectFit: "contain",
+                display: "block",
+              }}
+            />
+          </div>
         )}
       </Modal>
     </div>

--- a/shared/styles/markdown.css
+++ b/shared/styles/markdown.css
@@ -46,6 +46,7 @@ img {
   margin: 24px 0;
   max-width: 100%;
   height: auto;
+  cursor: zoom-in;
 }
 
 table {

--- a/views/blog-post/ui/BlogPostPage.tsx
+++ b/views/blog-post/ui/BlogPostPage.tsx
@@ -1,4 +1,5 @@
 import { getBlogPosts } from "@/entities/post";
+import { ContentImageViewer } from "@/components/ContentImageViewer";
 
 export async function BlogPostPage({
   params,
@@ -17,7 +18,11 @@ export async function BlogPostPage({
     );
   }
 
-  return <Content />;
+  return (
+    <ContentImageViewer>
+      <Content />
+    </ContentImageViewer>
+  );
 }
 
 export async function generateStaticParams() {


### PR DESCRIPTION
## Summary

- 블로그 본문 이미지 클릭 시 라이트박스 모달로 확대 뷰어 표시
- 이벤트 위임 방식으로 JSX `<img>` 태그도 포함, 모든 이미지 커버
- Dieter Rams 스타일 적용: sharp corners, no shadow, cream 배경, warm border, frameless 닫기 버튼

## Test plan

- [ ] 이미지가 있는 블로그 포스트 진입 (e.g. `/blog/2026-06-30-ab-testing`)
- [ ] 이미지 hover 시 `zoom-in` 커서 확인
- [ ] 이미지 클릭 시 모달 열림 확인
- [ ] 모달 내 이미지가 충분히 크게 표시되는지 확인
- [ ] ✕ 버튼 및 ESC / 오버레이 클릭으로 닫기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)